### PR TITLE
Dev server proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+OPENEVSE_ENDPOINT=http://localhost:3000
+#OPENEVSE_ENDPOINT=http://openevse.local
+DEV_HOST=localhost

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 stats.json
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -2948,6 +2948,12 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.1.0.tgz",
+      "integrity": "sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA==",
+      "dev": true
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2956,7 +2956,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@babel/preset-env": "^7.6.2",
     "clean-webpack-plugin": "^0.1.19",
     "css-loader": "^1.0.1",
+    "dotenv": "^8.1.0",
     "eslint": "^5.16.0",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "file-loader": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -8,3 +8,22 @@ This is the Web UI for OpenEVSE WiFi module. It is intended to be served via the
 npm install
 npm run build
 ```
+
+## Dev server
+
+To allow for easier development of the GUI there is a development server built in to Webpack. This can be configured to pass on calls to the backend to
+a real device or the simulator.
+
+### Config
+
+You can configure the dev server using [dotenv](https://www.npmjs.com/package/dotenv). An example `.env` file can be found [here](.env.example).
+
+`OPENEVSE_ENDPOINT` - URL of the OpenEVSE to test against.
+
+`DEV_HOST` - By default the dev server is only avalible to localhost. If you want to expose the server to the local network then set this to the IP address or hostname of the external network interface.
+
+### Starting
+
+To start the dev server use the command:
+
+`npm start`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,6 @@
+/* jslint node: true, esversion: 6 */
+/* eslint-env node */
+
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
@@ -9,6 +12,10 @@ const webpack = require("webpack"); //to access built-in plugins
 const path = require("path");
 const UglifyJS = require("uglify-js");
 const babel = require("@babel/core");
+
+require("dotenv").config();
+const openevseEndpoint = process.env.OPENEVSE_ENDPOINT || "http://openevse.local";
+const devHost = process.env.DEV_HOST || "localhost";
 
 var htmlMinify = {
   removeComments: true,
@@ -26,7 +33,30 @@ module.exports = {
     filename: "[name].js"
   },
   devServer: {
-    contentBase: "./dist"
+    host: devHost,
+    contentBase: "./dist",
+    index: "home.html",
+    proxy: [{
+      context: [
+        "/ws",
+        "/config",
+        "/status",
+        "/update",
+        "/r",
+        "/scan",
+        "/emoncms",
+        "/savenetwork",
+        "/saveemoncms",
+        "/savemqtt",
+        "/saveadmin",
+        "/saveohmkey",
+        "/reset",
+        "/restart",
+        "/apoff",
+        "/divertmode"
+      ],
+      target: openevseEndpoint
+    }]
   },
   module: {
     rules: [


### PR DESCRIPTION
Allow the dev server to proxy APIs to a real device or the simulator. This makes dev of the GUI much easier.