### PR TITLE
Pv divert ratio: adds a new parameter for Eco mode (when developper and grid I/E modes are activated)

### DIFF
--- a/src/home.htm
+++ b/src/home.htm
@@ -417,6 +417,12 @@
               </div>
             </div>
 
+            <p data-bind="visible: advancedMode() &amp;&amp; config.divert_enabled() &amp;&amp; config.mqtt_enabled() &amp;&amp; divertFeedType() === 'grid_ie'">
+              <b>Required PV power ratio:</b><br>
+              <input data-bind="textInput: config.divert_PV_ratio" type="number" autocapitalize="none" hint="1.0" min="0.05" max="1" step="0.01"><br>
+              <span class="small-text">The minimum fraction of charge current that must come from PV at all time </span>
+            </p>
+
             <p data-bind="visible: advancedMode() &amp;&amp; config.divert_enabled() &amp;&amp; config.mqtt_enabled()">
               <b>Divert smoothing attack:</b><br>
               <input data-bind="textInput: config.divert_attack_smoothing_factor" type="number" autocapitalize="none" hint="0.4" min="0" max="1" step="0.01"><br>

--- a/src/home.htm
+++ b/src/home.htm
@@ -420,7 +420,7 @@
             <p data-bind="visible: advancedMode() &amp;&amp; config.divert_enabled() &amp;&amp; config.mqtt_enabled() &amp;&amp; divertFeedType() === 'grid_ie'">
               <b>Required PV power ratio:</b><br>
               <input data-bind="textInput: config.divert_PV_ratio" type="number" autocapitalize="none" hint="1.0" min="0.05" max="1" step="0.01"><br>
-              <span class="small-text">The minimum fraction of charge current that must come from PV at all time </span>
+              <span class="small-text">The fraction of PV current that suffices to start charging or increment current </span>
             </p>
 
             <p data-bind="visible: advancedMode() &amp;&amp; config.divert_enabled() &amp;&amp; config.mqtt_enabled()">

--- a/src/home.htm
+++ b/src/home.htm
@@ -419,7 +419,7 @@
 
             <p data-bind="visible: advancedMode() &amp;&amp; config.divert_enabled() &amp;&amp; config.mqtt_enabled() &amp;&amp; divertFeedType() === 'grid_ie'">
               <b>Required PV power ratio:</b><br>
-              <input data-bind="textInput: config.divert_PV_ratio" type="number" autocapitalize="none" hint="1.0" min="0.05" max="1" step="0.01"><br>
+              <input data-bind="textInput: config.divert_PV_ratio" type="number" autocapitalize="none" hint="1.1" min="0.05" max="1.5" step="0.01"><br>
               <span class="small-text">The fraction of PV current that suffices to start charging or increment current </span>
             </p>
 

--- a/src/view_models/ConfigViewModel.js
+++ b/src/view_models/ConfigViewModel.js
@@ -49,6 +49,7 @@ function ConfigViewModel(baseEndpoint) {
     "version": "0.0.0",
     "time_zone": false,
     "divert_enabled": false,
+    "divert_PV_ratio": 1.0,
     "divert_attack_smoothing_factor": 0.4,
     "divert_decay_smoothing_factor": 0.05,
     "divert_min_charge_time": 600,

--- a/src/view_models/OpenEvseWiFiViewModel.js
+++ b/src/view_models/OpenEvseWiFiViewModel.js
@@ -493,6 +493,7 @@ function OpenEvseWiFiViewModel(baseHost, basePort, baseProtocol)
       divert_enabled: self.config.divert_enabled(),
       mqtt_solar: self.config.mqtt_solar(),
       mqtt_grid_ie: self.config.mqtt_grid_ie(),
+      divert_PV_ratio: self.config.divert_PV_ratio(),
       divert_attack_smoothing_factor: self.config.divert_attack_smoothing_factor(),
       divert_decay_smoothing_factor: self.config.divert_decay_smoothing_factor(),
       divert_min_charge_time: self.config.divert_min_charge_time()


### PR DESCRIPTION
Sending a new pull_request on the v3_gui branch.

The new parameter (divert_PV_ratio) sets the minimum fraction of PV power that needs to be available to either start charging or increment the charge current. See commit messages.