### PR TITLE
Remove embedded OhmConnect Vimeo video

### DIFF
--- a/src/home.htm
+++ b/src/home.htm
@@ -250,6 +250,8 @@
             </p>
             <p>
               <button data-bind="click: saveEmonCms, text: (saveEmonCmsFetching() ? 'Saving' : (saveEmonCmsSuccess() ? 'Saved' : 'Save')), disable: saveEmonCmsFetching">Save</button>
+            </p>
+            <p>
               <span data-bind="visible: config.emoncms_enabled"><b>&nbsp; Connected:&nbsp;<span data-bind="text: 1 === status.emoncms_connected() ? 'Yes' : 'No'"></span></b></span>
               <span data-bind="visible: config.emoncms_enabled() &amp;&amp; 1 === status.emoncms_connected()"><b>&nbsp; Successful posts:&nbsp;<span data-bind="text: status.packets_success"></span></b></span>
             </p>
@@ -359,9 +361,8 @@
             <p data-bind="visible: config.ohm_enabled">
               <strong>USA - California only</strong>
             </p>
-            <div style="padding:56.25% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/119419875" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
-              <p data-bind="visible: config.ohm_enabled">
-              Ohm Key can be obtained by logging in to OhmConnect, enter Settings and locate the link in "Open Source Projects"<br/>
+            <p data-bind="visible: config.ohm_enabled">
+              Ohm Key can be obtained by logging in to OhmConnect, enter Settings and locate the link in "Open Source Projects".<br/>
               Example: https://login.ohmconnect.com/verify-ohm-hour/OpnEoVse<br/>
               <b>Key: </b>OpnEoVse
             </p>


### PR DESCRIPTION
There is really no compelling reason for this to be here, and as issue
https://github.com/OpenEVSE/ESP32_WiFi_V3.x/issues/116 points out, it
requires making multiple requests out to an external domain, unlike
anything else in the web interface. We likely shouldn't be facilitating
unwanted tracking of people just trying to use their EVSE charger.

Note that this request is made every single time you load the web
interface as well, even if you never go to the "Services" tab, since it
is all a single HTML page.

I put one additional small display tweak in here- at the bottom of the EmonCMS pane, I moved the "Connected: xxx Successful Posts: yyy" to the next line after the "Save" button. 

Before:

<img width="355" alt="Screen Shot 2020-11-13 at 7 40 05 PM" src="https://user-images.githubusercontent.com/265817/99136142-fcde4e80-25e8-11eb-96b9-d2378a50a96b.png">

After:

<img width="350" alt="Screen Shot 2020-11-13 at 7 40 16 PM" src="https://user-images.githubusercontent.com/265817/99136146-036cc600-25e9-11eb-9c7d-acc0007052cf.png">
