### PR TITLE
Fix protocol check on HTTPS to enable WSS connections

### DIFF
--- a/src/view_models/StatusViewModel.js
+++ b/src/view_models/StatusViewModel.js
@@ -121,7 +121,7 @@ function StatusViewModel(baseEndpoint) {
   // -----------------------------------------------------------------------
   self.wsEndpoint = ko.pureComputed(function () {
     let base = new URL(baseEndpoint(), location.href);
-    var endpoint = ("https" === base.protocol ? "wss://" : "ws://") + base.hostname;
+    var endpoint = ("https:" === base.protocol ? "wss://" : "ws://") + base.hostname;
     if(80 !== base.port) {
       endpoint += ":"+base.port;
     }


### PR DESCRIPTION
The actual protocol is `https:` and not `https`, which in turn was leading to a `ws` connection on an HTTPS location, which is not allowed.

The check on `term.js` looks good.